### PR TITLE
Store metadata in WAL

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -58,6 +58,7 @@ import (
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/notifier"
 	_ "github.com/prometheus/prometheus/plugins" // Register plugins.
@@ -1382,6 +1383,10 @@ func (n notReadyAppender) Append(ref storage.SeriesRef, l labels.Labels, t int64
 }
 
 func (n notReadyAppender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	return 0, tsdb.ErrNotReady
+}
+
+func (n notReadyAppender) AppendMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
 	return 0, tsdb.ErrNotReady
 }
 

--- a/model/metadata/metadata.go
+++ b/model/metadata/metadata.go
@@ -1,0 +1,23 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import "github.com/prometheus/prometheus/model/textparse"
+
+// Metadata stores a series' metadata information.
+type Metadata struct {
+	Type textparse.MetricType
+	Unit string
+	Help string
+}

--- a/scrape/helpers_test.go
+++ b/scrape/helpers_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/storage"
 )
 
@@ -37,6 +38,11 @@ func (a nopAppender) Append(storage.SeriesRef, labels.Labels, int64, float64) (s
 func (a nopAppender) AppendExemplar(storage.SeriesRef, labels.Labels, exemplar.Exemplar) (storage.SeriesRef, error) {
 	return 0, nil
 }
+
+func (a nopAppender) AppendMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
+	return 0, nil
+}
+
 func (a nopAppender) Commit() error   { return nil }
 func (a nopAppender) Rollback() error { return nil }
 
@@ -55,6 +61,8 @@ type collectResultAppender struct {
 	rolledbackResult []sample
 	pendingExemplars []exemplar.Exemplar
 	resultExemplars  []exemplar.Exemplar
+	pendingMetadata  []metadata.Metadata
+	resultMetadata   []metadata.Metadata
 }
 
 func (a *collectResultAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
@@ -87,11 +95,25 @@ func (a *collectResultAppender) AppendExemplar(ref storage.SeriesRef, l labels.L
 	return a.next.AppendExemplar(ref, l, e)
 }
 
+func (a *collectResultAppender) AppendMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
+	a.pendingMetadata = append(a.pendingMetadata, m)
+	if ref == 0 {
+		ref = storage.SeriesRef(rand.Uint64())
+	}
+	if a.next == nil {
+		return ref, nil
+	}
+
+	return a.next.AppendMetadata(ref, l, m)
+}
+
 func (a *collectResultAppender) Commit() error {
 	a.result = append(a.result, a.pendingResult...)
 	a.resultExemplars = append(a.resultExemplars, a.pendingExemplars...)
+	a.resultMetadata = append(a.resultMetadata, a.pendingMetadata...)
 	a.pendingResult = nil
 	a.pendingExemplars = nil
+	a.pendingMetadata = nil
 	if a.next == nil {
 		return nil
 	}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -902,17 +902,15 @@ type scrapeCache struct {
 
 // metaEntry holds meta information about a metric.
 type metaEntry struct {
+	metadata.Metadata
+
 	lastIter       uint64 // Last scrape iteration the entry was observed at.
 	lastIterChange uint64 // Last scrape iteration the entry was changed at.
-
-	typ  textparse.MetricType
-	help string
-	unit string
 }
 
 func (m *metaEntry) size() int {
 	// The attribute lastIter although part of the struct it is not metadata.
-	return len(m.help) + len(m.unit) + len(m.typ)
+	return len(m.Help) + len(m.Unit) + len(m.Type)
 }
 
 func newScrapeCache() *scrapeCache {
@@ -1025,11 +1023,11 @@ func (c *scrapeCache) setType(metric []byte, t textparse.MetricType) {
 
 	e, ok := c.metadata[yoloString(metric)]
 	if !ok {
-		e = &metaEntry{typ: textparse.MetricTypeUnknown}
+		e = &metaEntry{Metadata: metadata.Metadata{Type: textparse.MetricTypeUnknown}}
 		c.metadata[string(metric)] = e
 	}
-	if e.typ != t {
-		e.typ = t
+	if e.Type != t {
+		e.Type = t
 		e.lastIterChange = c.iter
 	}
 	e.lastIter = c.iter
@@ -1042,11 +1040,11 @@ func (c *scrapeCache) setHelp(metric, help []byte) {
 
 	e, ok := c.metadata[yoloString(metric)]
 	if !ok {
-		e = &metaEntry{typ: textparse.MetricTypeUnknown}
+		e = &metaEntry{Metadata: metadata.Metadata{Type: textparse.MetricTypeUnknown}}
 		c.metadata[string(metric)] = e
 	}
-	if e.help != yoloString(help) {
-		e.help = string(help)
+	if e.Help != yoloString(help) {
+		e.Help = string(help)
 		e.lastIterChange = c.iter
 	}
 	e.lastIter = c.iter
@@ -1059,11 +1057,11 @@ func (c *scrapeCache) setUnit(metric, unit []byte) {
 
 	e, ok := c.metadata[yoloString(metric)]
 	if !ok {
-		e = &metaEntry{typ: textparse.MetricTypeUnknown}
+		e = &metaEntry{Metadata: metadata.Metadata{Type: textparse.MetricTypeUnknown}}
 		c.metadata[string(metric)] = e
 	}
-	if e.unit != yoloString(unit) {
-		e.unit = string(unit)
+	if e.Unit != yoloString(unit) {
+		e.Unit = string(unit)
 		e.lastIterChange = c.iter
 	}
 	e.lastIter = c.iter
@@ -1081,9 +1079,9 @@ func (c *scrapeCache) GetMetadata(metric string) (MetricMetadata, bool) {
 	}
 	return MetricMetadata{
 		Metric: metric,
-		Type:   m.typ,
-		Help:   m.help,
-		Unit:   m.unit,
+		Type:   m.Type,
+		Help:   m.Help,
+		Unit:   m.Unit,
 	}, true
 }
 
@@ -1096,9 +1094,9 @@ func (c *scrapeCache) ListMetadata() []MetricMetadata {
 	for m, e := range c.metadata {
 		res = append(res, MetricMetadata{
 			Metric: m,
-			Type:   e.typ,
-			Help:   e.help,
-			Unit:   e.unit,
+			Type:   e.Type,
+			Help:   e.Help,
+			Unit:   e.Unit,
 		})
 	}
 	return res
@@ -1518,14 +1516,14 @@ loop:
 			ref = ce.ref
 			lset = ce.lset
 
-			// Update metadata only if it's changed in the current iteration.
+			// Update metadata only if it changed in the current iteration.
 			sl.cache.metaMtx.Lock()
 			metaEntry, metaOk := sl.cache.metadata[yoloString(met)]
 			if metaOk && metaEntry.lastIterChange == sl.cache.iter {
 				shouldAppendMetadata = true
-				meta.Type = metaEntry.typ
-				meta.Unit = metaEntry.unit
-				meta.Help = metaEntry.help
+				meta.Type = metaEntry.Type
+				meta.Unit = metaEntry.Unit
+				meta.Help = metaEntry.Help
 			}
 			sl.cache.metaMtx.Unlock()
 		} else {
@@ -1557,9 +1555,9 @@ loop:
 			metaEntry, metaOk := sl.cache.metadata[yoloString(met)]
 			if metaOk {
 				shouldAppendMetadata = true
-				meta.Type = metaEntry.typ
-				meta.Unit = metaEntry.unit
-				meta.Help = metaEntry.help
+				meta.Type = metaEntry.Type
+				meta.Unit = metaEntry.Unit
+				meta.Help = metaEntry.Help
 			}
 			sl.cache.metaMtx.Unlock()
 		}
@@ -1602,10 +1600,9 @@ loop:
 		}
 
 		if shouldAppendMetadata {
-			_, metadataErr := app.AppendMetadata(ref, lset, meta)
-			if metadataErr != nil {
+			if _, merr := app.AppendMetadata(ref, lset, meta); merr != nil {
 				// No need to fail the scrape on errors appending metadata.
-				level.Debug(sl.l).Log("msg", "Error when appending metadata in scrape loop", "ref", fmt.Sprintf("%d", ref), "metadata", fmt.Sprintf("%+v", meta), "err", metadataErr)
+				level.Debug(sl.l).Log("msg", "Error when appending metadata in scrape loop", "ref", fmt.Sprintf("%d", ref), "metadata", fmt.Sprintf("%+v", meta), "err", merr)
 			}
 		}
 	}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1500,12 +1500,7 @@ loop:
 			t = *tp
 		}
 
-		// Zero metadata out until resolved, must be done since
-		// we use a pointer later to avoid copying arg by stack for
-		// low function call overhead and thus need to declare the local var
-		// above the loop so that it does not get allocated per
-		// entry in the scrape (which could happen if we took by pointer
-		// and declared the local var inside the for loop).
+		// Zero metadata out for current iteration until it's resolved.
 		meta = metadata.Metadata{}
 
 		if sl.cache.getDropped(yoloString(met)) {
@@ -1523,8 +1518,7 @@ loop:
 			ref = ce.ref
 			lset = ce.lset
 
-			// We should only update metadata for cached series if they've
-			// changed in the current iteration.
+			// Update metadata only if it's changed in the current iteration.
 			sl.cache.metaMtx.Lock()
 			metaEntry, metaOk := sl.cache.metadata[yoloString(met)]
 			if metaOk && metaEntry.lastIterChange == sl.cache.iter {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -42,6 +42,7 @@ import (
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -839,6 +840,7 @@ type cacheEntry struct {
 	lastIter uint64
 	hash     uint64
 	lset     labels.Labels
+	meta     metadata.Metadata
 }
 
 type scrapeLoop struct {
@@ -900,10 +902,12 @@ type scrapeCache struct {
 
 // metaEntry holds meta information about a metric.
 type metaEntry struct {
-	lastIter uint64 // Last scrape iteration the entry was observed at.
-	typ      textparse.MetricType
-	help     string
-	unit     string
+	lastIter       uint64 // Last scrape iteration the entry was observed at.
+	lastIterChange uint64 // Last scrape iteration the entry was changed at.
+
+	typ  textparse.MetricType
+	help string
+	unit string
 }
 
 func (m *metaEntry) size() int {
@@ -982,11 +986,11 @@ func (c *scrapeCache) get(met string) (*cacheEntry, bool) {
 	return e, true
 }
 
-func (c *scrapeCache) addRef(met string, ref storage.SeriesRef, lset labels.Labels, hash uint64) {
+func (c *scrapeCache) addRef(met string, ref storage.SeriesRef, lset labels.Labels, meta metadata.Metadata, hash uint64) {
 	if ref == 0 {
 		return
 	}
-	c.series[met] = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, hash: hash}
+	c.series[met] = &cacheEntry{ref: ref, lastIter: c.iter, lset: lset, meta: meta, hash: hash}
 }
 
 func (c *scrapeCache) addDropped(met string) {
@@ -1024,7 +1028,10 @@ func (c *scrapeCache) setType(metric []byte, t textparse.MetricType) {
 		e = &metaEntry{typ: textparse.MetricTypeUnknown}
 		c.metadata[string(metric)] = e
 	}
-	e.typ = t
+	if e.typ != t {
+		e.typ = t
+		e.lastIterChange = c.iter
+	}
 	e.lastIter = c.iter
 
 	c.metaMtx.Unlock()
@@ -1040,6 +1047,7 @@ func (c *scrapeCache) setHelp(metric, help []byte) {
 	}
 	if e.help != yoloString(help) {
 		e.help = string(help)
+		e.lastIterChange = c.iter
 	}
 	e.lastIter = c.iter
 
@@ -1056,6 +1064,7 @@ func (c *scrapeCache) setUnit(metric, unit []byte) {
 	}
 	if e.unit != yoloString(unit) {
 		e.unit = string(unit)
+		e.lastIterChange = c.iter
 	}
 	e.lastIter = c.iter
 
@@ -1438,6 +1447,7 @@ func (sl *scrapeLoop) append(app storage.Appender, b []byte, contentType string,
 		appErrs        = appendErrors{}
 		sampleLimitErr error
 		e              exemplar.Exemplar // escapes to heap so hoisted out of loop
+		meta           metadata.Metadata
 	)
 
 	// Take an appender with limits.
@@ -1455,8 +1465,9 @@ func (sl *scrapeLoop) append(app storage.Appender, b []byte, contentType string,
 loop:
 	for {
 		var (
-			et          textparse.Entry
-			sampleAdded bool
+			et                   textparse.Entry
+			sampleAdded          bool
+			shouldAppendMetadata bool
 		)
 		if et, err = p.Next(); err != nil {
 			if err == io.EOF {
@@ -1489,6 +1500,14 @@ loop:
 			t = *tp
 		}
 
+		// Zero metadata out until resolved, must be done since
+		// we use a pointer later to avoid copying arg by stack for
+		// low function call overhead and thus need to declare the local var
+		// above the loop so that it does not get allocated per
+		// entry in the scrape (which could happen if we took by pointer
+		// and declared the local var inside the for loop).
+		meta = metadata.Metadata{}
+
 		if sl.cache.getDropped(yoloString(met)) {
 			continue
 		}
@@ -1503,6 +1522,18 @@ loop:
 		if ok {
 			ref = ce.ref
 			lset = ce.lset
+
+			// We should only update metadata for cached series if they've
+			// changed in the current iteration.
+			sl.cache.metaMtx.Lock()
+			metaEntry, metaOk := sl.cache.metadata[yoloString(met)]
+			if metaOk && metaEntry.lastIterChange == sl.cache.iter {
+				shouldAppendMetadata = true
+				meta.Type = metaEntry.typ
+				meta.Unit = metaEntry.unit
+				meta.Help = metaEntry.help
+			}
+			sl.cache.metaMtx.Unlock()
 		} else {
 			mets = p.Metric(&lset)
 			hash = lset.Hash()
@@ -1527,6 +1558,16 @@ loop:
 				targetScrapePoolExceededLabelLimits.Inc()
 				break loop
 			}
+
+			sl.cache.metaMtx.Lock()
+			metaEntry, metaOk := sl.cache.metadata[yoloString(met)]
+			if metaOk {
+				shouldAppendMetadata = true
+				meta.Type = metaEntry.typ
+				meta.Unit = metaEntry.unit
+				meta.Help = metaEntry.help
+			}
+			sl.cache.metaMtx.Unlock()
 		}
 
 		ref, err = app.Append(ref, lset, t, v)
@@ -1543,7 +1584,7 @@ loop:
 				// Bypass staleness logic if there is an explicit timestamp.
 				sl.cache.trackStaleness(hash, lset)
 			}
-			sl.cache.addRef(mets, ref, lset, hash)
+			sl.cache.addRef(mets, ref, lset, meta, hash)
 			if sampleAdded && sampleLimitErr == nil {
 				seriesAdded++
 			}
@@ -1566,6 +1607,13 @@ loop:
 			e = exemplar.Exemplar{} // reset for next time round loop
 		}
 
+		if shouldAppendMetadata {
+			_, metadataErr := app.AppendMetadata(ref, lset, meta)
+			if metadataErr != nil {
+				// No need to fail the scrape on errors appending metadata.
+				level.Debug(sl.l).Log("msg", "Error when appending metadata in scrape loop", "ref", fmt.Sprintf("%d", ref), "metadata", fmt.Sprintf("%+v", meta), "err", metadataErr)
+			}
+		}
 	}
 	if sampleLimitErr != nil {
 		if err == nil {
@@ -1586,6 +1634,7 @@ loop:
 	if appErrs.numExemplarOutOfOrder > 0 {
 		level.Warn(sl.l).Log("msg", "Error on ingesting out-of-order exemplars", "num_dropped", appErrs.numExemplarOutOfOrder)
 	}
+
 	if err == nil {
 		sl.cache.forEachStale(func(lset labels.Labels) bool {
 			// Series no longer exposed, mark it stale.
@@ -1763,7 +1812,7 @@ func (sl *scrapeLoop) addReportSample(app storage.Appender, s string, t int64, v
 	switch errors.Cause(err) {
 	case nil:
 		if !ok {
-			sl.cache.addRef(s, ref, lset, lset.Hash())
+			sl.cache.addRef(s, ref, lset, metadata.Metadata{}, lset.Hash())
 		}
 		return nil
 	case storage.ErrOutOfOrderSample, storage.ErrDuplicateSampleForTimestamp:

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -1483,12 +1484,13 @@ func TestScrapeLoopAppendCacheEntryButErrNotFound(t *testing.T) {
 	require.NoError(t, warning)
 
 	var lset labels.Labels
+	var meta metadata.Metadata
 	p.Next()
 	mets := p.Metric(&lset)
 	hash := lset.Hash()
 
 	// Create a fake entry in the cache
-	sl.cache.addRef(mets, fakeRef, lset, hash)
+	sl.cache.addRef(mets, fakeRef, lset, meta, hash)
 	now := time.Now()
 
 	slApp := sl.appender(context.Background())

--- a/storage/fanout.go
+++ b/storage/fanout.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
 )
 
@@ -166,6 +167,20 @@ func (f *fanoutAppender) AppendExemplar(ref SeriesRef, l labels.Labels, e exempl
 
 	for _, appender := range f.secondaries {
 		if _, err := appender.AppendExemplar(ref, l, e); err != nil {
+			return 0, err
+		}
+	}
+	return ref, nil
+}
+
+func (f *fanoutAppender) AppendMetadata(ref SeriesRef, l labels.Labels, m metadata.Metadata) (SeriesRef, error) {
+	ref, err := f.primary.AppendMetadata(ref, l, m)
+	if err != nil {
+		return ref, err
+	}
+
+	for _, appender := range f.secondaries {
+		if _, err := appender.AppendMetadata(ref, l, m); err != nil {
 			return 0, err
 		}
 	}

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -252,9 +252,9 @@ type ExemplarAppender interface {
 	AppendExemplar(ref SeriesRef, l labels.Labels, e exemplar.Exemplar) (SeriesRef, error)
 }
 
-// MetadataAppender provides an interface for adding metadata to a storage.
+// MetadataAppender provides an interface for associating metadata to stored series.
 type MetadataAppender interface {
-	// AppendMetadata appends a metadata for the given series.
+	// AppendMetadata appends a metadata for the given series and labels.
 	// A series reference number is returned which can be used to modify the
 	// metadata of the given series in the same or later transactions.
 	// Returned reference numbers are ephemeral and may be rejected in calls

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 )
@@ -222,6 +223,7 @@ type Appender interface {
 	// Appender has to be discarded after rollback.
 	Rollback() error
 	ExemplarAppender
+	MetadataAppender
 }
 
 // GetRef is an extra interface on Appenders used by downstream projects
@@ -248,6 +250,18 @@ type ExemplarAppender interface {
 	// calls to Append should generate the reference numbers, AppendExemplar
 	// generating a new reference number should be considered possible erroneous behaviour and be logged.
 	AppendExemplar(ref SeriesRef, l labels.Labels, e exemplar.Exemplar) (SeriesRef, error)
+}
+
+// MetadataAppender provides an interface for adding metadata to a storage.
+type MetadataAppender interface {
+	// AppendMetadata appends a metadata for the given series.
+	// A series reference number is returned which can be used to modify the
+	// metadata of the given series in the same or later transactions.
+	// Returned reference numbers are ephemeral and may be rejected in calls
+	// to Append() at any point. Adding the sample via Append() returns a new
+	// reference number.
+	// If the reference is 0 it must not be used for caching.
+	AppendMetadata(ref SeriesRef, l labels.Labels, m metadata.Metadata) (SeriesRef, error)
 }
 
 // SeriesSet contains a set of series.

--- a/storage/remote/write.go
+++ b/storage/remote/write.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/wal"
 )
@@ -265,6 +266,12 @@ func (t *timestampTracker) Append(_ storage.SeriesRef, _ labels.Labels, ts int64
 
 func (t *timestampTracker) AppendExemplar(_ storage.SeriesRef, _ labels.Labels, _ exemplar.Exemplar) (storage.SeriesRef, error) {
 	t.exemplars++
+	return 0, nil
+}
+
+func (t *timestampTracker) AppendMetadata(_ storage.SeriesRef, _ labels.Labels, _ metadata.Metadata) (storage.SeriesRef, error) {
+	// TODO: Add and increment a `metadata` field when we get around to wiring metadata in remote_write.
+	// AppendMetadata is no-op for remote write (where timestampTracker is being used) for now.
 	return 0, nil
 }
 

--- a/storage/remote/write_handler_test.go
+++ b/storage/remote/write_handler_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/storage"
 )
@@ -184,5 +185,11 @@ func (m *mockAppendable) AppendExemplar(_ storage.SeriesRef, l labels.Labels, e 
 
 	m.latestExemplar = e.Ts
 	m.exemplars = append(m.exemplars, mockExemplar{l, e.Labels, e.Ts, e.Value})
+	return 0, nil
+}
+
+func (m *mockAppendable) AppendMetadata(_ storage.SeriesRef, _ labels.Labels, _ metadata.Metadata) (storage.SeriesRef, error) {
+	// TODO: Wire metadata in a mockAppendable field when we get around to handling metadata in remote_write.
+	// AppendMetadata is no-op for remote write (where mockAppendable is being used to test) for now.
 	return 0, nil
 }

--- a/tsdb/agent/db.go
+++ b/tsdb/agent/db.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
@@ -796,6 +797,10 @@ func (a *appender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exem
 	})
 
 	return storage.SeriesRef(s.ref), nil
+}
+
+func (a *appender) AppendMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
+	return 0, nil
 }
 
 // Commit submits the collected samples and purges the batch.

--- a/tsdb/docs/format/wal.md
+++ b/tsdb/docs/format/wal.md
@@ -50,6 +50,29 @@ Series records encode the labels that identifies a series and its unique ID.
 └────────────────────────────────────────────┘
 ```
 
+### Metadata records
+
+Metadata records encode the metadata associated with a series.
+
+```
+┌────────────────────────────────────────────┐
+│ type = 1 <1b>                              │
+├────────────────────────────────────────────┤
+│ ┌────────────────────────────────────────┐ │
+│ │ id <uvarint>                           │ │
+│ ├────────────────────────────────────────┤ │
+│ │ size <uvarint>                         │ │
+│ ├─────────────────────┬──────────────────┤ │
+│ │ len(type) <uvarint> │ type <bytes>     │ │
+│ ├─────────────────────┴──────────────────┤ │
+│ │ len(unit) <uvarint> │ unit <bytes>     │ │
+│ ├─────────────────────┴──────────────────┤ │
+│ │ len(help) <uvarint> │ help <bytes>     │ │
+│ └─────────────────────┴──────────────────┘ │
+│                  . . .                     │
+└────────────────────────────────────────────┘
+```
+
 ### Sample records
 
 Sample records encode samples as a list of triples `(series_id, timestamp, value)`.

--- a/tsdb/docs/format/wal.md
+++ b/tsdb/docs/format/wal.md
@@ -62,9 +62,9 @@ Metadata records encode the metadata associated with a series.
 │ │ id <uvarint>                           │ │
 │ ├────────────────────────────────────────┤ │
 │ │ size <uvarint>                         │ │
+│ ├────────────────────────────────────────┤ │
+│ │ type <1b>                              │ │
 │ ├─────────────────────┬──────────────────┤ │
-│ │ len(type) <uvarint> │ type <bytes>     │ │
-│ ├─────────────────────┴──────────────────┤ │
 │ │ len(unit) <uvarint> │ unit <bytes>     │ │
 │ ├─────────────────────┴──────────────────┤ │
 │ │ len(help) <uvarint> │ help <bytes>     │ │

--- a/tsdb/head.go
+++ b/tsdb/head.go
@@ -31,6 +31,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -75,6 +76,7 @@ type Head struct {
 	logger          log.Logger
 	appendPool      sync.Pool
 	exemplarsPool   sync.Pool
+	metadataPool    sync.Pool
 	seriesPool      sync.Pool
 	bytesPool       sync.Pool
 	memChunkPool    sync.Pool
@@ -1508,6 +1510,7 @@ type memSeries struct {
 
 	ref  chunks.HeadSeriesRef
 	lset labels.Labels
+	meta metadata.Metadata
 
 	// Immutable chunks on disk that have not yet gone into a block, in order of ascending time stamps.
 	// When compaction runs, chunks get moved into a block and all pointers are shifted like so:

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -395,15 +395,15 @@ func (a *headAppender) AppendMetadata(ref storage.SeriesRef, lset labels.Labels,
 		return 0, fmt.Errorf("unknown HeadSeriesRef when trying to add metadata: %d", ref)
 	}
 
-	hasNewMetadata := false
-	s.Lock()
-	if s.meta != meta {
-		hasNewMetadata = true
-		s.meta = meta
-	}
-	s.Unlock()
+	s.RLock()
+	hasNewMetadata := s.meta != meta
+	s.RUnlock()
 
 	if hasNewMetadata {
+		s.Lock()
+		s.meta = meta
+		s.Unlock()
+
 		a.metadata = append(a.metadata, record.RefMetadata{
 			Ref:  s.ref,
 			Type: s.meta.Type,

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -406,7 +406,7 @@ func (a *headAppender) AppendMetadata(ref storage.SeriesRef, lset labels.Labels,
 
 		a.metadata = append(a.metadata, record.RefMetadata{
 			Ref:  s.ref,
-			Type: s.meta.Type,
+			Type: record.GetMetricType(s.meta.Type),
 			Unit: s.meta.Unit,
 			Help: s.meta.Help,
 		})

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -299,7 +299,6 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 	}
 
 	s.Lock()
-
 	if err := s.appendable(t, v); err != nil {
 		s.Unlock()
 		if err == storage.ErrOutOfOrderSample {
@@ -323,7 +322,6 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 		V:   v,
 	})
 	a.sampleSeries = append(a.sampleSeries, s)
-
 	return storage.SeriesRef(s.ref), nil
 }
 
@@ -386,7 +384,6 @@ func (a *headAppender) AppendExemplar(ref storage.SeriesRef, lset labels.Labels,
 }
 
 func (a *headAppender) AppendMetadata(ref storage.SeriesRef, lset labels.Labels, meta metadata.Metadata) (storage.SeriesRef, error) {
-	// Get Series
 	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
 	if s == nil {
 		s = a.head.series.getByHash(lset.Hash(), lset)
@@ -399,7 +396,6 @@ func (a *headAppender) AppendMetadata(ref storage.SeriesRef, lset labels.Labels,
 	}
 
 	hasNewMetadata := false
-
 	s.Lock()
 	if s.meta != meta {
 		hasNewMetadata = true

--- a/tsdb/head_append.go
+++ b/tsdb/head_append.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -63,6 +64,15 @@ func (a *initAppender) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e 
 	a.app = a.head.appender()
 
 	return a.app.AppendExemplar(ref, l, e)
+}
+
+func (a *initAppender) AppendMetadata(ref storage.SeriesRef, l labels.Labels, m metadata.Metadata) (storage.SeriesRef, error) {
+	if a.app != nil {
+		return a.app.AppendMetadata(ref, l, m)
+	}
+
+	a.app = a.head.appender()
+	return a.app.AppendMetadata(ref, l, m)
 }
 
 // initTime initializes a head with the first timestamp. This only needs to be called
@@ -130,6 +140,7 @@ func (h *Head) appender() *headAppender {
 		samples:               h.getAppendBuffer(),
 		sampleSeries:          h.getSeriesBuffer(),
 		exemplars:             exemplarsBuf,
+		metadata:              h.getMetadataBuffer(),
 		appendID:              appendID,
 		cleanupAppendIDsBelow: cleanupAppendIDsBelow,
 	}
@@ -196,6 +207,19 @@ func (h *Head) putExemplarBuffer(b []exemplarWithSeriesRef) {
 	h.exemplarsPool.Put(b[:0])
 }
 
+func (h *Head) getMetadataBuffer() []record.RefMetadata {
+	b := h.metadataPool.Get()
+	if b == nil {
+		return make([]record.RefMetadata, 0, 512)
+	}
+	return b.([]record.RefMetadata)
+}
+
+func (h *Head) putMetadataBuffer(b []record.RefMetadata) {
+	//nolint:staticcheck // Ignore SA6002 safe to ignore and actually fixing it has some performance penalty.
+	h.metadataPool.Put(b[:0])
+}
+
 func (h *Head) getSeriesBuffer() []*memSeries {
 	b := h.seriesPool.Get()
 	if b == nil {
@@ -233,6 +257,7 @@ type headAppender struct {
 	mint, maxt   int64
 
 	series       []record.RefSeries      // New series held by this appender.
+	metadata     []record.RefMetadata    // New metadata held by this appender.
 	samples      []record.RefSample      // New samples held by this appender.
 	exemplars    []exemplarWithSeriesRef // New exemplars held by this appender.
 	sampleSeries []*memSeries            // Series corresponding to the samples held by this appender (using corresponding slice indices - same series may appear more than once).
@@ -274,6 +299,7 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 	}
 
 	s.Lock()
+
 	if err := s.appendable(t, v); err != nil {
 		s.Unlock()
 		if err == storage.ErrOutOfOrderSample {
@@ -297,6 +323,7 @@ func (a *headAppender) Append(ref storage.SeriesRef, lset labels.Labels, t int64
 		V:   v,
 	})
 	a.sampleSeries = append(a.sampleSeries, s)
+
 	return storage.SeriesRef(s.ref), nil
 }
 
@@ -358,6 +385,40 @@ func (a *headAppender) AppendExemplar(ref storage.SeriesRef, lset labels.Labels,
 	return storage.SeriesRef(s.ref), nil
 }
 
+func (a *headAppender) AppendMetadata(ref storage.SeriesRef, lset labels.Labels, meta metadata.Metadata) (storage.SeriesRef, error) {
+	// Get Series
+	s := a.head.series.getByID(chunks.HeadSeriesRef(ref))
+	if s == nil {
+		s = a.head.series.getByHash(lset.Hash(), lset)
+		if s != nil {
+			ref = storage.SeriesRef(s.ref)
+		}
+	}
+	if s == nil {
+		return 0, fmt.Errorf("unknown HeadSeriesRef when trying to add metadata: %d", ref)
+	}
+
+	hasNewMetadata := false
+
+	s.Lock()
+	if s.meta != meta {
+		hasNewMetadata = true
+		s.meta = meta
+	}
+	s.Unlock()
+
+	if hasNewMetadata {
+		a.metadata = append(a.metadata, record.RefMetadata{
+			Ref:  s.ref,
+			Type: s.meta.Type,
+			Unit: s.meta.Unit,
+			Help: s.meta.Help,
+		})
+	}
+
+	return ref, nil
+}
+
 var _ storage.GetRef = &headAppender{}
 
 func (a *headAppender) GetRef(lset labels.Labels) (storage.SeriesRef, labels.Labels) {
@@ -387,6 +448,14 @@ func (a *headAppender) log() error {
 
 		if err := a.head.wal.Log(rec); err != nil {
 			return errors.Wrap(err, "log series")
+		}
+	}
+	if len(a.metadata) > 0 {
+		rec = enc.Metadata(a.metadata, buf)
+		buf = rec[:0]
+
+		if err := a.head.wal.Log(rec); err != nil {
+			return errors.Wrap(err, "log metadata")
 		}
 	}
 	if len(a.samples) > 0 {
@@ -449,6 +518,7 @@ func (a *headAppender) Commit() (err error) {
 	defer a.head.putAppendBuffer(a.samples)
 	defer a.head.putSeriesBuffer(a.sampleSeries)
 	defer a.head.putExemplarBuffer(a.exemplars)
+	defer a.head.putMetadataBuffer(a.metadata)
 	defer a.head.iso.closeAppend(a.appendID)
 
 	total := len(a.samples)
@@ -614,8 +684,10 @@ func (a *headAppender) Rollback() (err error) {
 	}
 	a.head.putAppendBuffer(a.samples)
 	a.head.putExemplarBuffer(a.exemplars)
+	a.head.putMetadataBuffer(a.metadata)
 	a.samples = nil
 	a.exemplars = nil
+	a.metadata = nil
 
 	// Series are created in the head memory regardless of rollback. Thus we have
 	// to log them to the WAL in any case.

--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -63,7 +63,7 @@ type RefSample struct {
 	V   float64
 }
 
-// RefMetadata is the series metadata.
+// RefMetadata is the metadata associated with a series ID.
 type RefMetadata struct {
 	Ref  chunks.HeadSeriesRef
 	Type textparse.MetricType

--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/encoding"
@@ -42,6 +43,8 @@ const (
 	Tombstones Type = 3
 	// Exemplars is used to match WAL records of type Exemplars.
 	Exemplars Type = 4
+	// Metadata is used to match WAL records of type Metadata.
+	Metadata Type = 5
 )
 
 // ErrNotFound is returned if a looked up resource was not found. Duplicate ErrNotFound from head.go.
@@ -58,6 +61,14 @@ type RefSample struct {
 	Ref chunks.HeadSeriesRef
 	T   int64
 	V   float64
+}
+
+// RefMetadata is the series metadata.
+type RefMetadata struct {
+	Ref  chunks.HeadSeriesRef
+	Type textparse.MetricType
+	Unit string
+	Help string
 }
 
 // RefExemplar is an exemplar with it's labels, timestamp, value the exemplar was collected/observed with, and a reference to a series.
@@ -79,7 +90,7 @@ func (d *Decoder) Type(rec []byte) Type {
 		return Unknown
 	}
 	switch t := Type(rec[0]); t {
-	case Series, Samples, Tombstones, Exemplars:
+	case Series, Samples, Tombstones, Exemplars, Metadata:
 		return t
 	}
 	return Unknown
@@ -115,6 +126,48 @@ func (d *Decoder) Series(rec []byte, series []RefSeries) ([]RefSeries, error) {
 		return nil, errors.Errorf("unexpected %d bytes left in entry", len(dec.B))
 	}
 	return series, nil
+}
+
+// Metadata appends metadata in rec to the given slice.
+func (d *Decoder) Metadata(rec []byte, metadata []RefMetadata) ([]RefMetadata, error) {
+	dec := encoding.Decbuf{B: rec}
+
+	if Type(dec.Byte()) != Metadata {
+		return nil, errors.New("invalid record type")
+	}
+	for len(dec.B) > 0 && dec.Err() == nil {
+		ref := dec.Uvarint64()
+		size := dec.Uvarint()
+
+		remainingBeforeReadFields := dec.Len()
+
+		typ := dec.UvarintStr()
+		unit := dec.UvarintStr()
+		help := dec.UvarintStr()
+
+		// The bytes consumed will have shrunk, therefore delta between
+		// bytes unread before and bytes unread after is how much we consumed.
+		remainingAfterReadFields := dec.Len()
+		sizeFieldsRead := remainingBeforeReadFields - remainingAfterReadFields
+		if sizeFieldsUnread := size - sizeFieldsRead; sizeFieldsUnread > 0 {
+			// Need to skip fields that we didn't read and don't know about.
+			dec.Skip(sizeFieldsUnread)
+		}
+
+		metadata = append(metadata, RefMetadata{
+			Ref:  chunks.HeadSeriesRef(ref),
+			Type: textparse.MetricType(typ),
+			Unit: unit,
+			Help: help,
+		})
+	}
+	if dec.Err() != nil {
+		return nil, dec.Err()
+	}
+	if len(dec.B) > 0 {
+		return nil, errors.Errorf("unexpected %d bytes left in entry", len(dec.B))
+	}
+	return metadata, nil
 }
 
 // Samples appends samples in rec to the given slice.
@@ -241,6 +294,29 @@ func (e *Encoder) Series(series []RefSeries, b []byte) []byte {
 			buf.PutUvarintStr(l.Value)
 		}
 	}
+	return buf.Get()
+}
+
+// Metadata appends the encoded metadata to b and returns the resulting slice.
+func (e *Encoder) Metadata(metadata []RefMetadata, b []byte) []byte {
+	buf := encoding.Encbuf{B: b}
+	buf.PutByte(byte(Metadata))
+
+	for _, m := range metadata {
+		buf.PutUvarint64(uint64(m.Ref))
+
+		// Use a temporary buffer to get the size of the fields
+		// that we're going to encode before writing the fields themselves.
+		tmp := encoding.Encbuf{B: []byte{}}
+		tmp.PutUvarintStr(string(m.Type))
+		tmp.PutUvarintStr(string(m.Unit))
+		tmp.PutUvarintStr(string(m.Help))
+
+		// Write the size of the temporary buffer and copy back the encoded fields into place.
+		buf.PutUvarint(tmp.Len())
+		buf.B = append(buf.B, tmp.B...)
+	}
+
 	return buf.Get()
 }
 

--- a/tsdb/record/record.go
+++ b/tsdb/record/record.go
@@ -47,6 +47,41 @@ const (
 	Metadata Type = 5
 )
 
+// MetricType represents the type of a series.
+type MetricType uint8
+
+const (
+	UnknownMT      MetricType = 0
+	Counter        MetricType = 1
+	Gauge          MetricType = 2
+	Histogram      MetricType = 3
+	GaugeHistogram MetricType = 4
+	Summary        MetricType = 5
+	Info           MetricType = 6
+	Stateset       MetricType = 7
+)
+
+func GetMetricType(t textparse.MetricType) uint8 {
+	switch t {
+	case textparse.MetricTypeCounter:
+		return uint8(Counter)
+	case textparse.MetricTypeGauge:
+		return uint8(Gauge)
+	case textparse.MetricTypeHistogram:
+		return uint8(Histogram)
+	case textparse.MetricTypeGaugeHistogram:
+		return uint8(GaugeHistogram)
+	case textparse.MetricTypeSummary:
+		return uint8(Summary)
+	case textparse.MetricTypeInfo:
+		return uint8(Info)
+	case textparse.MetricTypeStateset:
+		return uint8(Stateset)
+	default:
+		return uint8(UnknownMT)
+	}
+}
+
 // ErrNotFound is returned if a looked up resource was not found. Duplicate ErrNotFound from head.go.
 var ErrNotFound = errors.New("not found")
 
@@ -66,7 +101,7 @@ type RefSample struct {
 // RefMetadata is the metadata associated with a series ID.
 type RefMetadata struct {
 	Ref  chunks.HeadSeriesRef
-	Type textparse.MetricType
+	Type uint8
 	Unit string
 	Help string
 }
@@ -141,7 +176,7 @@ func (d *Decoder) Metadata(rec []byte, metadata []RefMetadata) ([]RefMetadata, e
 
 		remainingBeforeReadFields := dec.Len()
 
-		typ := dec.UvarintStr()
+		typ := dec.Byte()
 		unit := dec.UvarintStr()
 		help := dec.UvarintStr()
 
@@ -156,7 +191,7 @@ func (d *Decoder) Metadata(rec []byte, metadata []RefMetadata) ([]RefMetadata, e
 
 		metadata = append(metadata, RefMetadata{
 			Ref:  chunks.HeadSeriesRef(ref),
-			Type: textparse.MetricType(typ),
+			Type: typ,
 			Unit: unit,
 			Help: help,
 		})
@@ -308,7 +343,7 @@ func (e *Encoder) Metadata(metadata []RefMetadata, b []byte) []byte {
 		// Use a temporary buffer to get the size of the fields
 		// that we're going to encode before writing the fields themselves.
 		tmp := encoding.Encbuf{B: []byte{}}
-		tmp.PutUvarintStr(string(m.Type))
+		tmp.PutByte(m.Type)
 		tmp.PutUvarintStr(string(m.Unit))
 		tmp.PutUvarintStr(string(m.Help))
 

--- a/tsdb/record/record_test.go
+++ b/tsdb/record/record_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/model/textparse"
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/tombstones"
 )
@@ -49,19 +48,19 @@ func TestRecord_EncodeDecode(t *testing.T) {
 	metadata := []RefMetadata{
 		{
 			Ref:  100,
-			Type: textparse.MetricTypeCounter,
+			Type: uint8(Counter),
 			Unit: "",
 			Help: "some magic counter",
 		},
 		{
 			Ref:  1,
-			Type: textparse.MetricTypeCounter,
+			Type: uint8(Counter),
 			Unit: "seconds",
 			Help: "CPU time counter",
 		},
 		{
 			Ref:  147741,
-			Type: textparse.MetricTypeGauge,
+			Type: uint8(Gauge),
 			Unit: "percentage",
 			Help: "current memory usage",
 		},
@@ -197,7 +196,7 @@ func TestRecord_MetadataDecodeUnknownFields(t *testing.T) {
 	// Write first metadata entry, all known fields.
 	enc.PutUvarint64(101)
 	encFields.Reset()
-	encFields.PutUvarintStr(string(textparse.MetricTypeCounter))
+	encFields.PutByte(byte(Counter))
 	encFields.PutUvarintStr("")
 	encFields.PutUvarintStr("some magic counter")
 	// Write size of encoded fields then the encoded fields.
@@ -208,7 +207,7 @@ func TestRecord_MetadataDecodeUnknownFields(t *testing.T) {
 	enc.PutUvarint64(99)
 	encFields.Reset()
 	// Known fields.
-	encFields.PutUvarintStr(string(textparse.MetricTypeCounter))
+	encFields.PutByte(byte(Counter))
 	encFields.PutUvarintStr("seconds")
 	encFields.PutUvarintStr("CPU time counter")
 	// Unknown fields.
@@ -222,7 +221,7 @@ func TestRecord_MetadataDecodeUnknownFields(t *testing.T) {
 	// Write third metadata entry, all known fields.
 	enc.PutUvarint64(47250)
 	encFields.Reset()
-	encFields.PutUvarintStr(string(textparse.MetricTypeGauge))
+	encFields.PutByte(byte(Gauge))
 	encFields.PutUvarintStr("percentage")
 	encFields.PutUvarintStr("current memory usage")
 	// Write size of encoded fields then the encoded fields.
@@ -233,17 +232,17 @@ func TestRecord_MetadataDecodeUnknownFields(t *testing.T) {
 	expectedMetadata := []RefMetadata{
 		{
 			Ref:  101,
-			Type: textparse.MetricTypeCounter,
+			Type: uint8(Counter),
 			Unit: "",
 			Help: "some magic counter",
 		}, {
 			Ref:  99,
-			Type: textparse.MetricTypeCounter,
+			Type: uint8(Counter),
 			Unit: "seconds",
 			Help: "CPU time counter",
 		}, {
 			Ref:  47250,
-			Type: textparse.MetricTypeGauge,
+			Type: uint8(Gauge),
 			Unit: "percentage",
 			Help: "current memory usage",
 		},

--- a/tsdb/wal/checkpoint.go
+++ b/tsdb/wal/checkpoint.go
@@ -42,10 +42,12 @@ type CheckpointStats struct {
 	DroppedSamples    int
 	DroppedTombstones int
 	DroppedExemplars  int
+	DroppedMetadata   int
 	TotalSeries       int // Processed series including dropped ones.
 	TotalSamples      int // Processed samples including dropped ones.
 	TotalTombstones   int // Processed tombstones including dropped ones.
 	TotalExemplars    int // Processed exemplars including dropped ones.
+	TotalMetadata     int // Processed metadata including dropped ones.
 }
 
 // LastCheckpoint returns the directory name and index of the most recent checkpoint.
@@ -85,7 +87,7 @@ const checkpointPrefix = "checkpoint."
 
 // Checkpoint creates a compacted checkpoint of segments in range [from, to] in the given WAL.
 // It includes the most recent checkpoint if it exists.
-// All series not satisfying keep and samples/tombstones/exemplars below mint are dropped.
+// All series not satisfying keep and samples/tombstones/exemplars/metadata below mint are dropped.
 //
 // The checkpoint is stored in a directory named checkpoint.N in the same
 // segmented format as the original WAL itself.
@@ -150,13 +152,14 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id chunks.Hea
 		samples   []record.RefSample
 		tstones   []tombstones.Stone
 		exemplars []record.RefExemplar
+		metadata  []record.RefMetadata
 		dec       record.Decoder
 		enc       record.Encoder
 		buf       []byte
 		recs      [][]byte
 	)
 	for r.Next() {
-		series, samples, tstones, exemplars = series[:0], samples[:0], tstones[:0], exemplars[:0]
+		series, samples, tstones, exemplars, metadata = series[:0], samples[:0], tstones[:0], exemplars[:0], metadata[:0]
 
 		// We don't reset the buffer since we batch up multiple records
 		// before writing them to the checkpoint.
@@ -239,6 +242,23 @@ func Checkpoint(logger log.Logger, w *WAL, from, to int, keep func(id chunks.Hea
 			}
 			stats.TotalExemplars += len(exemplars)
 			stats.DroppedExemplars += len(exemplars) - len(repl)
+		case record.Metadata:
+			metadata, err := dec.Metadata(rec, metadata)
+			if err != nil {
+				return nil, errors.Wrap(err, "decode metadata")
+			}
+			// Drop irrelevant metadata in place.
+			repl := metadata[:0]
+			for _, m := range metadata {
+				if keep(m.Ref) {
+					repl = append(repl, m)
+				}
+			}
+			if len(repl) > 0 {
+				buf = enc.Metadata(repl, buf)
+			}
+			stats.TotalMetadata += len(metadata)
+			stats.DroppedMetadata += len(metadata) - len(repl)
 		default:
 			// Unknown record type, probably from a future Prometheus version.
 			continue


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <paschalist0@gmail.com>

## Changes
This PR updates Prometheus to store metadata in its Write-Ahead Log. To achieve this, a new `MetadataAppender` interface is introduced and embedded in Appender.

Its method implementation is used to store a `RefMetadata` slice as a headAppender field, which is then encoded in the WAL according to the proposed format.

The scrape loop is also modified to detect changes in metadata in both new and old (cached) series and pass them along.

To verify that metadata is indeed appended to the WAL, I use a commit such as tpaschalis/prometheus@fd36aabb3fff2ead259c6f559f3c9b3020f107a9 to check and print metadata in the loadWAL method.

## Prior Art
This is an attempt at a revival of 7771 and other discussions around storing and utilizing Metadata throughout Prometheus. 

Unlike the reference work, this only deals with appending metadata to the WAL, and aims to start a bigger discussion around how we can make Metadata more useful throughout Prometheus.

As such, reading from the WAL and sending over to remote_write is not in the scope of this PR and will be handled with a future pull request..

Older Mailing list discussion: https://groups.google.com/g/prometheus-developers/c/w-eotGenBGg/m/UZWdxzcBBwAJ

Older Design doc: https://docs.google.com/document/d/1LY8Im8UyIBn8e3LJ2jB-MoajXkfAqW2eKzY735aYxqo/edit#heading=h.bik9uwphqy3g


## Notes
After I get some feedback on the overall idea, I will extend the test suite to cover more cases and increase overall confidence on how the feature works and interacts with different pieces of Prometheus.
